### PR TITLE
Put back instructions screen and add some color to splash screen

### DIFF
--- a/assets/common.less
+++ b/assets/common.less
@@ -62,7 +62,7 @@ a {
 }
 
 /*
-  The main content of the mini.
+  The main content of the data story.
   The --app-content-height allows the app to shrink when the text is open
  */
 #main-content {
@@ -176,10 +176,9 @@ a {
   }
 }
 
-
-
 /* Splash screen */
 #splash-overlay {
+  background-image: radial-gradient( #a14d69,#715a6a,#6d7799,#6f95c1);
   position: fixed;
   align-items: center;
   justify-content: center;
@@ -401,7 +400,6 @@ video {
   & h3 {
     margin-top: calc(var(--default-line-height));
     margin-bottom: calc(0.3 * var(--default-line-height));
-    color: var(--accent-color2);
   }
 
   & p {

--- a/src/Radwave.vue
+++ b/src/Radwave.vue
@@ -326,6 +326,7 @@
                     <v-col cols="12">
                       <div class="credits">
                       <h3>Credits:</h3>
+                      <p>This Data Story is powered by WorldWide Telescope.</p>
                       <h4><a href="https://www.cosmicds.cfa.harvard.edu/" target="_blank" rel="noopener noreferrer">CosmicDS</a> Team:</h4>
                       Jon Carifio<br>
                       John Lewis<br>
@@ -526,7 +527,7 @@ export default defineComponent({
       layersLoaded: false,
       positionSet: false,
       
-      userNotReady: false, //Action needed!! reset to true
+      userNotReady: true, //Action needed!! reset to true
 
       
       accentColor: "#427cff",
@@ -657,6 +658,7 @@ export default defineComponent({
     cssVars() {
       return {
         '--accent-color': this.accentColor,
+        '--accent-color2': this.accentColor2,
         '--app-content-height': this.showTextSheet ? '66%' : '100%',
       };
     },
@@ -1112,6 +1114,7 @@ export default defineComponent({
 
 #modal-loading {
 
+  background-color: #000;
 
   @media (max-width: 699px) {
     background-image: url("./assets/radwave_landing_mobile.png");


### PR DESCRIPTION
This is what the Splash Screen background looks like. I used some colors sampled from the Milky Way view. We can update as requested by the SME team.

<img width="1007" alt="Screenshot 2024-02-16 at 8 56 40 AM" src="https://github.com/cosmicds/radwave-in-motion/assets/12750048/ef51b2d5-7777-4b25-b7f1-bcccb746f476">
