### PR TITLE
fix touchscreen control text

### DIFF
--- a/src/Radwave.vue
+++ b/src/Radwave.vue
@@ -320,7 +320,7 @@
                       </v-chip>
                     </v-col>
                     <v-col cols="8" class="pt-1">
-                      <strong>{{ touchscreen ? "press + drag" : "click + drag" }}</strong>  {{ touchscreen ? ":" : "or" }}  <strong>{{ touchscreen ? ":" : "W-A-S-D" }}</strong> {{ touchscreen ? ":" : "keys" }}<br>
+                      <strong>{{ touchscreen ? "press + drag" : "click + drag" }}</strong>  {{ touchscreen ? "" : "or" }}  <strong>{{ touchscreen ? "" : "W-A-S-D" }}</strong> {{ touchscreen ? "" : "keys" }}<br>
                     </v-col>
                   </v-row>
                   <v-row align="center">
@@ -333,7 +333,7 @@
                       </v-chip>
                     </v-col>
                     <v-col cols="8" class="pt-1">
-                      <strong>{{ touchscreen ? "pinch in and out" : "scroll in and out" }}</strong> {{ touchscreen ? ":" : "or" }} <strong>{{ touchscreen ? ":" : "I-O" }}</strong> {{ touchscreen ? ":" : "keys" }}<br>
+                      <strong>{{ touchscreen ? "pinch in and out" : "scroll in and out" }}</strong> {{ touchscreen ? "" : "or" }} <strong>{{ touchscreen ? "" : "I-O" }}</strong> {{ touchscreen ? "" : "keys" }}<br>
                     </v-col>
                   </v-row>
                   <v-row>


### PR DESCRIPTION
on touch screen we this displayed. Instead of `""` being displayed it was set to display `":"`. This fixes that
![image](https://github.com/cosmicds/radwave-in-motion/assets/7862929/53637433-9278-4c72-988c-d0e78f1bd491)
