### PR TITLE
Add query parameters for skipping splash and/or intro screens

### DIFF
--- a/src/Radwave.vue
+++ b/src/Radwave.vue
@@ -530,6 +530,10 @@ export default defineComponent({
     }
   },
   data() {
+    const search = new URLSearchParams(window.location.search);
+    const showSplashScreen = search.get("splash")?.toLowerCase() !== "false";
+    const introQuery = search.get("intro")?.toLowerCase() !== "false";
+    const userNotReady = introQuery;
     const initialOpacity = 0.2;
     const fadeStartPhase = 100;
     const fadeEndPhase = 270;
@@ -550,16 +554,19 @@ export default defineComponent({
       zoomDeg: 360,
       instant: true
     }  as GotoRADecZoomParams;
+
+    if (!showSplashScreen) {
+      this.closeSplashScreen();
+    }
     
     return {
-      showSplashScreen: true, //Action needed!! reset to true
+      showSplashScreen,
       backgroundImagesets: [] as BackgroundImageset[],
       sheet: null as SheetType,
       layersLoaded: false,
       positionSet: false,
       
-      userNotReady: true, //Action needed!! reset to true
-
+      userNotReady,
       
       accentColor: "#427cff",
       accentColor2: "#FF0000",


### PR DESCRIPTION
This PR resolves #12 by adding query parameter handling to allow skipping the splash and/or intro screens. To use this, put the following in the URL search parameters:
* `splash=false`: If this is set, the splash screen won't be displayed
* `intro=false`: If this is false, the intro screen will either not be displayed, or displayed only until data has finished loading and then automatically advance

These two parameters can be used independently. As mentioned in the description of `intro`, the intro screen may still pop up even if `intro=false`, but this will only be until the data has finished loading, and then it will advance automatically without needing to press the Start button. I think that's fine, since the data will need to load anyway, and this is something that's only relevant in a development context.